### PR TITLE
Fix an error when options.log is not true

### DIFF
--- a/src/index.cjs
+++ b/src/index.cjs
@@ -7,7 +7,7 @@ module.exports = class Figurecon {
 	#defaults;
 	#hooks;
 
-	#logger;
+	#logger = () => {};
 	#watcher;
 	#fileName;
 


### PR DESCRIPTION
If the constructor is called with the parameter `options.log` not equal to `true`, this error is thrown when another error has to be caught in `#require` method: 
```
/mnt/storageA/git/rngnrs/figurecon/src/index.cjs:92
			this.#logger(e);
			            ^

TypeError: this[#logger] is not a function
```

This PR adds an empty default value for `#logger` method, so that it is always a function, even when it's not in use.